### PR TITLE
Change the build to not shade signature files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+/target
+/dependency-reduced-pom.xml

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Heap Dump Parser
 
 run Heappo and add the "graph" parameter
 
-`java org.adoptopenjdk.jheappo.Heappo "/path/to/file.hprof" graph`
+`java -jar path/to/jheappo.jar "/path/to/file.hprof" graph`
 
 It will create a `graph.db` directory.
 

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,26 @@
                         <goals>
                             <goal>shade</goal>
                         </goals>
+                        <configuration>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <transformers>
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <manifestEntries>
+                                        <Main-Class>org.adoptopenjdk.jheappo.Heappo</Main-Class>
+                                    </manifestEntries>
+                                </transformer>
+                            </transformers>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
This avoids "java.lang.SecurityException: Invalid signature file" errors
at startup.*

Also, give the jar a Main-Class while I was in there mucking about in
the manifest since it's intended to be used as an executable jar anyway.

*Shading signed jars seems to be the issue, which I guess is fair... a signature for a dependency's jar certainly ought to fail when used in a shaded jar!
```
Error: A JNI error has occurred, please check your installation and try again
Exception in thread "main" java.lang.SecurityException: Invalid signature file digest for Manifest main attributes
	at java.base/sun.security.util.SignatureFileVerifier.processImpl(SignatureFileVerifier.java:336)
	at java.base/sun.security.util.SignatureFileVerifier.process(SignatureFileVerifier.java:269)
	at java.base/java.util.jar.JarVerifier.processEntry(JarVerifier.java:316)
	at java.base/java.util.jar.JarVerifier.update(JarVerifier.java:230)
	at java.base/java.util.jar.JarFile.initializeVerifier(JarFile.java:758)
	at java.base/java.util.jar.JarFile.ensureInitialization(JarFile.java:1035)
	at java.base/java.util.jar.JavaUtilJarAccessImpl.ensureInitialization(JavaUtilJarAccessImpl.java:69)
	at java.base/jdk.internal.loader.URLClassPath$JarLoader$2.getManifest(URLClassPath.java:870)
	at java.base/jdk.internal.loader.BuiltinClassLoader.defineClass(BuiltinClassLoader.java:788)
	at java.base/jdk.internal.loader.BuiltinClassLoader.findClassOnClassPathOrNull(BuiltinClassLoader.java:700)
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClassOrNull(BuiltinClassLoader.java:623)
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:581)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:521)
	at java.base/java.lang.Class.forName0(Native Method)
	at java.base/java.lang.Class.forName(Class.java:415)
	at java.base/sun.launcher.LauncherHelper.loadMainClass(LauncherHelper.java:760)
	at java.base/sun.launcher.LauncherHelper.checkAndLoadMain(LauncherHelper.java:655)
```